### PR TITLE
fix null ptr, fix warning on virtual method

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -197,7 +197,7 @@ public:
                                DWOUnits.end());
   }
 
-  virtual StringRef getCompilationDirectory();
+  StringRef getCompilationDirectory();
 
   /// Get compile units in the DWO context.
   compile_unit_range dwo_compile_units() {

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
@@ -293,6 +293,8 @@ public:
   private:
     uint32_t findRowInSeq(const DWARFDebugLine::Sequence &Seq,
                           object::SectionedAddress Address) const;
+    uint32_t findRowInSeqOld(const DWARFDebugLine::Sequence &Seq,
+                          object::SectionedAddress Address) const;
     std::optional<StringRef>
     getSourceByIndex(uint64_t FileIndex,
                      DILineInfoSpecifier::FileLineInfoKind Kind) const;

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -699,7 +699,11 @@ void DWARFContext::dump(
 }
 
 StringRef DWARFContext::getCompilationDirectory() {
-  return StringRef(getCompileUnitForOffset(0)->getCompilationDir());
+  DWARFCompileUnit * unitForOffset = getCompileUnitForOffset(0);
+  if (unitForOffset == nullptr) {
+    return StringRef("");
+  }
+  return StringRef(unitForOffset->getCompilationDir());
 }
 
 DWARFTypeUnit *DWARFContext::getTypeUnitForHash(uint16_t Version, uint64_t Hash,

--- a/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
@@ -295,7 +295,7 @@ DILineInfo SymbolizableObjectFile::symbolizeCode(object::SectionedAddress Module
   // HACK: Upstream doesn't have the getCompilationDirectory() function.
   std::string FullPath = LineInfo.FileName;
   std::string Prefix = DebugInfoContext->getCompilationDirectory().str();
-  if (Prefix.back() != '/') {
+  if (Prefix.empty() || Prefix.back() != '/') {
     Prefix.push_back('/');
   }
 


### PR DESCRIPTION
check for nullptr after calling getCompileUnitForOffset(0)
remove virtual as this generated a compiler warning (it wasn't overridden)