### PR TITLE
Prepare for kepler

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -197,7 +197,7 @@ public:
                                DWOUnits.end());
   }
 
-  virtual StringRef getCompilationDirectory();
+  StringRef getCompilationDirectory();
 
   /// Get compile units in the DWO context.
   compile_unit_range dwo_compile_units() {

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -699,7 +699,11 @@ void DWARFContext::dump(
 }
 
 StringRef DWARFContext::getCompilationDirectory() {
-  return StringRef(getCompileUnitForOffset(0)->getCompilationDir());
+  DWARFCompileUnit * unitForOffset = getCompileUnitForOffset(0);
+  if (unitForOffset == nullptr) {
+    return StringRef("");
+  }
+  return StringRef(unitForOffset->getCompilationDir());
 }
 
 DWARFTypeUnit *DWARFContext::getTypeUnitForHash(uint16_t Version, uint64_t Hash,

--- a/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
@@ -295,7 +295,7 @@ DILineInfo SymbolizableObjectFile::symbolizeCode(object::SectionedAddress Module
   // HACK: Upstream doesn't have the getCompilationDirectory() function.
   std::string FullPath = LineInfo.FileName;
   std::string Prefix = DebugInfoContext->getCompilationDirectory().str();
-  if (Prefix.back() != '/') {
+  if (Prefix.empty() || Prefix.back() != '/') {
     Prefix.push_back('/');
   }
 


### PR DESCRIPTION
A couple of fixes for code that I've already added and tested.

Related to https://github.com/bugsnag/llvm-project/pull/3 that already was reviewed and tested in canary, but doesn't include the logic for inverting the order of symbols in lookup, this was a hacky fix I added when we were trying to align the results of this version with the legacy version we currently use. I think it's best not to include that here as itt might cause confusion or even result in an incorrect symbol being returned.

Related to changes in https://github.com/bugsnag/llvm-project/pull/1 In this PR I made changes to add methods to obtain the compilation directory. The location had moved and we use it to normalize file paths. However in canary I found these  bugs with the code that I added. Both effectively nullptrs.