### PR TITLE
patch that removes compilation dir from filename on inlined frames

### DIFF
--- a/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
@@ -332,6 +332,19 @@ DIInliningInfo SymbolizableObjectFile::symbolizeInlinedCode(
       LI->FileName = FileName;
   }
 
+  // HACK:CI This strips projectRoot in the bugsnag-expected manner.
+  for (int i = 0; i < InlinedContext.getNumberOfFrames(); i++) {
+    DILineInfo *LI = InlinedContext.getMutableFrame(i);
+    std::string FullPath = LI->FileName;
+    std::string Prefix = DebugInfoContext->getCompilationDirectory().str();
+    if (Prefix.empty() || Prefix.back() != '/') {
+      Prefix.push_back('/');
+    }
+
+    if (FullPath.length() > Prefix.length() && FullPath.substr(0, Prefix.length()) == Prefix) {
+      LI->FileName = FullPath.substr(Prefix.length());
+    }
+  }
 
   return InlinedContext;
 }


### PR DESCRIPTION
We apply a similar patch on L295 when not requesting inlined frames

Tested against [this](https://github.com/bugsnag/bugsnag-dsym/pull/35/) branch of bugsnag-dsym that adds inlined frames and got the correct result (same as old llvm)