### PR TITLE
PIPE-8933 xcode26 fix

### DIFF
--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -249,7 +249,7 @@ public:
     return true;
   }
 
-  virtual StringRef getCompilationDirectory() {
+  virtual StringRef getCompilationDirectory(uint64_t Address) {
     return StringRef("");
   }
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -197,7 +197,7 @@ public:
                                DWOUnits.end());
   }
 
-  StringRef getCompilationDirectory();
+  StringRef getCompilationDirectory(uint64_t Address);
 
   /// Get compile units in the DWO context.
   compile_unit_range dwo_compile_units() {

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -699,23 +699,26 @@ void DWARFContext::dump(
 }
 
 StringRef DWARFContext::getCompilationDirectory(uint64_t Address) {
+  // Historic logic that checks the DW_AT_comp_dir flag of the first compile unit
   DWARFCompileUnit * unitForOffset = getCompileUnitForOffset(0);
   if (unitForOffset == nullptr) {
     return StringRef("");
   }
   
-  StringRef baseCompDir = StringRef(unitForOffset->getCompilationDir());
+  StringRef compDir = StringRef(unitForOffset->getCompilationDir());
   
-  // XCode26 dSYMs compiled with global first units, detected by "/" compilation directory
-  // then revert to CU relative file paths.
-  if (baseCompDir.equals(StringRef("/"))) {
-    DWARFCompileUnit *CU = getCompileUnitForDataAddress(Address);
-    if (!CU)
+  // XCode26 dSYMs compiled with global first units, detected by "/" compilation directory of the first compile unit
+  // instead get the DW_AT_comp_dir from the compile unit of the provided address.
+  if (compDir.equals(StringRef("/"))) {
+    unitForOffset = getCompileUnitForDataAddress(Address);
+    if (unitForOffset == nullptr) {
       return StringRef("");
-    baseCompDir = StringRef(CU->getCompilationDir());
+    }
+
+    compDir = StringRef(unitForOffset->getCompilationDir());
   }
 
-  return baseCompDir;
+  return compDir;
 }
 
 DWARFTypeUnit *DWARFContext::getTypeUnitForHash(uint16_t Version, uint64_t Hash,

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -707,8 +707,8 @@ StringRef DWARFContext::getCompilationDirectory(uint64_t Address) {
   
   StringRef compDir = StringRef(unitForOffset->getCompilationDir());
   
-  // XCode26 dSYMs compiled with global first units, detected by "/" compilation directory of the first compile unit
-  // instead get the DW_AT_comp_dir from the compile unit of the provided address.
+  // dSYMs can be compiled with some global first CUs, detected by "/" compilation directory of the first compile unit
+  // instead of using '/' get the DW_AT_comp_dir from the compile unit of the provided address.
   if (compDir.equals(StringRef("/"))) {
     unitForOffset = getCompileUnitForDataAddress(Address);
     if (unitForOffset == nullptr) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -698,12 +698,24 @@ void DWARFContext::dump(
     getDebugNames().dump(OS);
 }
 
-StringRef DWARFContext::getCompilationDirectory() {
+StringRef DWARFContext::getCompilationDirectory(uint64_t Address) {
   DWARFCompileUnit * unitForOffset = getCompileUnitForOffset(0);
   if (unitForOffset == nullptr) {
     return StringRef("");
   }
-  return StringRef(unitForOffset->getCompilationDir());
+  
+  StringRef baseCompDir = StringRef(unitForOffset->getCompilationDir());
+  
+  // XCode26 dSYMs compiled with global first units, detected by "/" compilation directory
+  // then revert to CU relative file paths.
+  if (baseCompDir.equals(StringRef("/"))) {
+    DWARFCompileUnit *CU = getCompileUnitForDataAddress(Address);
+    if (!CU)
+      return StringRef("");
+    baseCompDir = StringRef(CU->getCompilationDir());
+  }
+
+  return baseCompDir;
 }
 
 DWARFTypeUnit *DWARFContext::getTypeUnitForHash(uint16_t Version, uint64_t Hash,

--- a/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/SymbolizableObjectFile.cpp
@@ -294,7 +294,7 @@ DILineInfo SymbolizableObjectFile::symbolizeCode(object::SectionedAddress Module
   // HACK:CI This strips projectRoot in the bugsnag-expected manner.
   // HACK: Upstream doesn't have the getCompilationDirectory() function.
   std::string FullPath = LineInfo.FileName;
-  std::string Prefix = DebugInfoContext->getCompilationDirectory().str();
+  std::string Prefix = DebugInfoContext->getCompilationDirectory(ModuleOffset.Address).str();
   if (Prefix.empty() || Prefix.back() != '/') {
     Prefix.push_back('/');
   }
@@ -332,15 +332,16 @@ DIInliningInfo SymbolizableObjectFile::symbolizeInlinedCode(
       LI->FileName = FileName;
   }
 
+  std::string Prefix = DebugInfoContext->getCompilationDirectory(ModuleOffset.Address).str();
+  if (Prefix.empty() || Prefix.back() != '/') {
+    Prefix.push_back('/');
+  }
+  
   // HACK:CI This strips projectRoot in the bugsnag-expected manner.
   for (int i = 0; i < InlinedContext.getNumberOfFrames(); i++) {
     DILineInfo *LI = InlinedContext.getMutableFrame(i);
     std::string FullPath = LI->FileName;
-    std::string Prefix = DebugInfoContext->getCompilationDirectory().str();
-    if (Prefix.empty() || Prefix.back() != '/') {
-      Prefix.push_back('/');
-    }
-
+    
     if (FullPath.length() > Prefix.length() && FullPath.substr(0, Prefix.length()) == Prefix) {
       LI->FileName = FullPath.substr(Prefix.length());
     }


### PR DESCRIPTION
Fixes an issue for dSYMs built with XCode26.

We have some old logic that takes the first compile unit to get the compilation directory and makes filenames relative to that if applicable. The newer version of xcode is building dSYMs where the first CU has a compilation directory of '/'

We can't just switch to use relative paths as it would break existing groupings (where compilation directory is different from the project compilation directory e.g. libraries)

This change intends to target XC26 dSYMs by identifying the compilation directory of '/' in the first CU and in that case return a relative path for the filename of returned symbol. This is a change in behaviour, but it seems more correct for all paths to be relative to the CU. There may be some regrouping in included libraries but will fix the already broken file groupings.

See https://github.com/bugsnag/bugsnag-dsym/pull/38 for test

Note: I manually tested an apple library file path and it was unchanged behaviour.