### PR TITLE
Pipe 9691 relative filepath issue

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -474,9 +474,6 @@ private:
   void addLocalsForDie(DWARFCompileUnit *CU, DWARFDie Subprogram, DWARFDie Die,
                        std::vector<DILocal> &Result);
                        
-  // Cache for the last computed full source file path
-  mutable std::string CachedFullSourcePath;
-  mutable uint64_t CachedAddressForPath = 0;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -473,6 +473,10 @@ private:
 
   void addLocalsForDie(DWARFCompileUnit *CU, DWARFDie Subprogram, DWARFDie Die,
                        std::vector<DILocal> &Result);
+                       
+  // Cache for the last computed full source file path
+  mutable std::string CachedFullSourcePath;
+  mutable uint64_t CachedAddressForPath = 0;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -473,7 +473,6 @@ private:
 
   void addLocalsForDie(DWARFCompileUnit *CU, DWARFDie Subprogram, DWARFDie Die,
                        std::vector<DILocal> &Result);
-                       
 };
 
 } // end namespace llvm

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -710,43 +710,9 @@ StringRef DWARFContext::getCompilationDirectory(uint64_t Address) {
   // dSYMs can be compiled with some global first CUs, detected by "/" compilation directory of the first compile unit
   // instead of using '/' get the DW_AT_comp_dir from the compile unit of the provided address.
   if (compDir.equals(StringRef("/"))) {
-    unitForOffset = getCompileUnitForDataAddress(Address);
-    if (unitForOffset == nullptr) {
-      return StringRef("");
-    }
-
-    compDir = StringRef(unitForOffset->getCompilationDir());
+    return StringRef("");
   }
   
-  // Extract full source file path from line table
-  // Get the line table and extract the actual source file name to combine with compDir
-  if (const DWARFDebugLine::LineTable *LineTable = getLineTableForUnit(unitForOffset)) {
-    std::vector<uint32_t> RowVector;
-    if (LineTable->lookupAddressRange({Address, 0}, 1, RowVector) && !RowVector.empty()) {
-      const DWARFDebugLine::Row &Row = LineTable->Rows[RowVector[0]];
-      
-      // Get the file name from the line table
-      std::string FileName;
-      LineTable->getFileNameByIndex(Row.File, unitForOffset->getCompilationDir(),
-                                    DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath,
-                                    FileName);
-      
-      // If we already have absolute path, cache and return it
-      if (sys::path::is_absolute(FileName)) {
-        CachedFullSourcePath = FileName;
-        CachedAddressForPath = Address;
-        return StringRef(CachedFullSourcePath);
-      }
-      
-      // Combine compilation directory with relative file name and cache it
-      if (!compDir.empty() && compDir != "/") {
-        CachedFullSourcePath = std::string(compDir) + "/" + FileName;
-        CachedAddressForPath = Address;
-        return StringRef(CachedFullSourcePath);
-      }
-    }
-  }
-
   return compDir;
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -712,7 +712,6 @@ StringRef DWARFContext::getCompilationDirectory(uint64_t Address) {
   if (compDir.equals(StringRef("/"))) {
     return StringRef("");
   }
-  
   return compDir;
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -717,6 +717,35 @@ StringRef DWARFContext::getCompilationDirectory(uint64_t Address) {
 
     compDir = StringRef(unitForOffset->getCompilationDir());
   }
+  
+  // Extract full source file path from line table
+  // Get the line table and extract the actual source file name to combine with compDir
+  if (const DWARFDebugLine::LineTable *LineTable = getLineTableForUnit(unitForOffset)) {
+    std::vector<uint32_t> RowVector;
+    if (LineTable->lookupAddressRange({Address, 0}, 1, RowVector) && !RowVector.empty()) {
+      const DWARFDebugLine::Row &Row = LineTable->Rows[RowVector[0]];
+      
+      // Get the file name from the line table
+      std::string FileName;
+      LineTable->getFileNameByIndex(Row.File, unitForOffset->getCompilationDir(),
+                                    DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath,
+                                    FileName);
+      
+      // If we already have absolute path, cache and return it
+      if (sys::path::is_absolute(FileName)) {
+        CachedFullSourcePath = FileName;
+        CachedAddressForPath = Address;
+        return StringRef(CachedFullSourcePath);
+      }
+      
+      // Combine compilation directory with relative file name and cache it
+      if (!compDir.empty() && compDir != "/") {
+        CachedFullSourcePath = std::string(compDir) + "/" + FileName;
+        CachedAddressForPath = Address;
+        return StringRef(CachedFullSourcePath);
+      }
+    }
+  }
 
   return compDir;
 }


### PR DESCRIPTION
**Summary**: Returning absolute filepath in case of xcode 26
**Testing results before fix:**
<img width="1667" height="265" alt="image" src="https://github.com/user-attachments/assets/52ac66d0-3ad3-4b8f-b2f2-cb4812c7b25a" />
**After fix:**
<img width="1678" height="294" alt="image" src="https://github.com/user-attachments/assets/0aa1ac04-0ab6-4c1d-9d33-f786e51ad36b" />
