### PR TITLE
PIPE-10037 Bump certifi

### DIFF
--- a/llvm/utils/git/requirements.txt
+++ b/llvm/utils/git/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.txt.in
 #
-certifi==2022.9.24
+certifi==2022.12.07
     # via requests
 cffi==1.15.1
     # via pynacl


### PR DESCRIPTION
Update the pinned certifi dependency used by the LLVM Git helper requirements file from 2022.9.24 to 2022.12.07. This keeps the bundled CA certificate set current for the request's dependency.