### PR TITLE
PIPE-10047 Bump idna

### DIFF
--- a/llvm/utils/git/requirements.txt
+++ b/llvm/utils/git/requirements.txt
@@ -16,7 +16,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.30
     # via -r requirements.txt.in
-idna==3.4
+idna==3.7
     # via requests
 pycparser==2.21
     # via cffi

--- a/llvm/utils/git/requirements.txt
+++ b/llvm/utils/git/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.txt.in
 #
-certifi==2022.9.24
+certifi==2022.12.07
     # via requests
 cffi==1.15.1
     # via pynacl

--- a/llvm/utils/git/requirements.txt
+++ b/llvm/utils/git/requirements.txt
@@ -5,7 +5,9 @@
 #    pip-compile --output-file=requirements.txt requirements.txt.in
 #
 certifi==2022.12.07
-    # via requests
+    # via
+    #   -r requirements.txt.in
+    #   requests
 cffi==1.15.1
     # via pynacl
 charset-normalizer==2.1.1
@@ -17,7 +19,9 @@ gitdb==4.0.9
 gitpython==3.1.30
     # via -r requirements.txt.in
 idna==3.7
-    # via requests
+    # via
+    #   -r requirements.txt.in
+    #   requests
 pycparser==2.21
     # via cffi
 pygithub==1.55

--- a/llvm/utils/git/requirements.txt.in
+++ b/llvm/utils/git/requirements.txt.in
@@ -5,3 +5,5 @@
 
 PyGithub
 GitPython
+certifi==2022.12.07
+idna==3.7


### PR DESCRIPTION
Update pinned dependency versions in the LLVM Git helper requirements:
* certifi: 2022.9.24 → 2022.12.07
* idna: 3.4 → 3.7

Both dependencies are now explicitly pinned in requirements.txt.in and the lockfile has been regenerated. This ensures the bumps are reproducible and won't be reverted by future pip-compile runs.

Impact:
* Limited to the optional Python Git helper tooling under git
* Updates the CA certificate bundle (certifi) and internationalized domain name handling (idna) used by the requests library
* No impact to LLVM/Clang build or core functionality

Files changed:
* requirements.txt.in: Added explicit version constraints
* requirements.txt: Regenerated lockfile with updated pins